### PR TITLE
changed production environment mail settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,15 +64,17 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    :port => 587,
-    :address => "smtp.mailgun.org",
-    :domain => ENV['MAILGUN_DOMAIN'],
-    :user_name => ENV['MAILGUN_SMTP_LOGIN'],
-    :password => ENV['MAILGUN_SMTP_PASSWORD'],
-    :authentication => :plain
-  }
-
+ 
+  Mail.defaults do
+    delivery_method :smtp, {
+      :address => 'smtp.gmail.com',
+      :port => '587',
+      :user_name => ENV['GMAILUSER'],
+      :password => ENV['GMAILPASSWORD'],
+      :authentication => :plain,
+      :enable_starttls_auto => true
+    }
+  end
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
I changed the mailer values in the production environment.  I think this should fix our sending emails issue on qa.  I was not able to test the production environment on my localhost, it required a secret key and token and after several different approaches I failed to make it work.  So, we can merge and push to heroku to test or I can figure out how to make it work locally.