### PR TITLE
fixed the bloody invite to rfp buttons issue on loi index page

### DIFF
--- a/app/assets/javascripts/lois_index_ctrl.js
+++ b/app/assets/javascripts/lois_index_ctrl.js
@@ -84,35 +84,39 @@
         return "No Ratings";
       }
     };
-    $scope.truthValue = false;
 
     $scope.inviteSent = function(status, loi_id){
       var dupes = $scope.invited_lois.filter(function(invited_lois) {
-        return invited_lois.loi_id === parseInt(loi_id) && invited_lois.status;
+        return invited_lois.loi_id === parseInt(loi_id);
       });
-      // console.log(dupes);
       if (dupes.length === 0) {
         var updatedStatus = {
           status: true,
-          loi_id: loi_id
+          loi_id: loi_id,
         };
-        console.log(updatedStatus);
-        console.log(updatedStatus);
 
 
         $http.post('/api/v1/invited_lois/', updatedStatus).then(function(response){
           console.log(response.data);
           $scope.invited_lois.push(response.data);
-          // document.getElementById("invitebtns").innerHTML = "<button class='btn btn-error btn-invite inactive-btn'>Invited</button>";
         });
-        $scope.truthValue = true;
 
-        $scope.btnText = "Invited";
+         
+      
       } else {
         alert("error");
       }
     };
-  
+
+
+    $scope.changeBtn = function(repeatScope) {
+      if (repeatScope.isDisabled) {
+        repeatScope.isDisabled = false;
+      } else {
+        repeatScope.btnText = "Invited";
+        repeatScope.isDisabled = true;
+      }
+    };
 
   }]);
 

--- a/app/views/lois/index.html.erb
+++ b/app/views/lois/index.html.erb
@@ -61,7 +61,7 @@
 
                 <% end %>
                   <% if current_user && current_user.super_admin %>
-                    <button class="btn btn-info btn-invite" ng-class="{'disabled': truthValue}" ng-click="inviteSent(loi_status, loi.id); clickit()" ng-if="loi.invited_lois[0].status != true">{{btnText}}</button>
+                    <button class="btn btn-info btn-invite" ng-class="{'disabled': isDisabled}" ng-click="inviteSent(loi_status, loi.id); changeBtn(this)" ng-if="loi.invited_lois[0].status != true">{{btnText}}</button>
                     <button class="btn btn-error btn-invite disabled" ng-if="loi.invited_lois[0].status == true">Invited</button>   
                   <% else %>
                     <button class="btn btn-danger btn-rate disabled" ng-if="loi.invited_lois[0].status != true">Super Admin action required</button>


### PR DESCRIPTION
Before: when you'd click "invite to rfp" all others would turn to invited, even if they weren't (until you refreshed the page). 
Now: only the button you click will change its text to "invited"